### PR TITLE
Variable sides

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1,4 +1,4 @@
- 
+/* eslint-disable */
 // @ts-nocheck
 // biome-ignore lint: disable
 // oxlint-disable

--- a/src/components/Cassette.vue
+++ b/src/components/Cassette.vue
@@ -31,6 +31,19 @@ function removeCassette() {
   layoutStore.calculateLayout()
 }
 
+function addSide() {
+  if (cassette.value == undefined) return
+  cassetteStore.updateSidesCount(props.cassetteId, cassette.value.sidesCount + 1)
+  layoutStore.calculateLayout()
+}
+
+function removeSide() {
+  if (cassette.value == undefined) return
+  if (cassette.value.sidesCount <= 1) return
+  cassetteStore.updateSidesCount(props.cassetteId, cassette.value.sidesCount - 1)
+  layoutStore.calculateLayout()
+}
+
 const capacityMinutes = computed<number>({
   get() {
     const ms = cassette.value?.capacityMs ?? 0
@@ -61,18 +74,28 @@ const name = computed<string>({
         <v-select v-model="capacityMinutes" :items="cassetteStore.possibleLengthsMin" density="compact" hide-details
           class="ma-0" style="min-width:150px" label="Capacity (min)" />
       </template>
+
       <template v-slot:title>
         <v-text-field v-model="name" density="compact" hide-details placeholder="Cassette name"
           class="cassette-title-field" />
       </template>
-      <template v-slot:append>
-        <v-btn icon @click="addCassette" title="Add cassette">
-          <v-icon>mdi-playlist-plus</v-icon>
-        </v-btn>
-        <v-btn v-if="cassetteStore.cassettes.length > 1" icon @click="removeCassette" title="Remove cassette">
-          <v-icon>mdi-playlist-minus</v-icon>
-        </v-btn>
-      </template>
+
+      <v-menu>
+        <template v-slot:activator="{ props }">
+          <v-btn icon="mdi-dots-vertical" variant="text" v-bind="props"></v-btn>
+        </template>
+
+        <v-list>
+          <v-list-subheader>Cassette</v-list-subheader>
+          <v-divider />
+          <v-list-item title="Add cassette" @click="addCassette" />
+          <v-list-item title="Remove this cassette" @click="removeCassette" />
+          <v-list-subheader>Sides</v-list-subheader>
+          <v-divider />
+          <v-list-item title="Add side" @click="addSide" />
+          <v-list-item title="Remove side" @click="removeSide" :disabled="cassette!.sidesCount <= 1" />
+        </v-list>
+      </v-menu>
     </v-toolbar>
     <v-alert v-if="topAlert" type="warning" variant="outlined">
       <div class="d-flex justify-space-between align-center w-100">
@@ -84,7 +107,8 @@ const name = computed<string>({
       </div>
     </v-alert>
     <v-row class="pa-2">
-      <v-col v-for="index in Array.from({ length: cassette?.sidesCount || 0 }, (_, i) => i)" :key="index">
+      <v-col v-for="index in Array.from({ length: cassette?.sidesCount || 0 }, (_, i) => i)" :key="index" cols="12"
+        sm="6">
         <CassetteSide :cassetteId="cassetteId" :sideIndex="index" />
       </v-col>
     </v-row>

--- a/src/components/Cassette.vue
+++ b/src/components/Cassette.vue
@@ -41,6 +41,7 @@ function removeSide() {
   if (cassette.value == undefined) return
   if (cassette.value.sidesCount <= 1) return
   cassetteStore.updateSidesCount(props.cassetteId, cassette.value.sidesCount - 1)
+  anchorsStore.removeAnchorsByTapeSide(props.cassetteId, cassette.value.sidesCount)
   layoutStore.calculateLayout()
 }
 

--- a/src/components/Cassette.vue
+++ b/src/components/Cassette.vue
@@ -84,14 +84,8 @@ const name = computed<string>({
       </div>
     </v-alert>
     <v-row class="pa-2">
-      <v-col>
-        <CassetteSide :cassetteId="cassetteId" :sideIndex="0" />
-      </v-col>
-
-      <v-divider vertical class="full-height-divider" />
-
-      <v-col>
-        <CassetteSide :cassetteId="cassetteId" :sideIndex="1" />
+      <v-col v-for="index in Array.from({ length: cassette?.sidesCount || 0 }, (_, i) => i)" :key="index">
+        <CassetteSide :cassetteId="cassetteId" :sideIndex="index" />
       </v-col>
     </v-row>
   </v-card>

--- a/src/components/CassetteSide.vue
+++ b/src/components/CassetteSide.vue
@@ -60,7 +60,7 @@ async function onChanged(event: DragChangeEvent<string>) {
 
 const durationChipColor = computed(() => {
   if (!layout.value || !cassette?.value) return 'secondary'
-  return (layout.value.durationMs ?? 0) > (cassette.value.capacityMs / 2) ? 'error' : 'secondary'
+  return (layout.value.durationMs ?? 0) > (cassette.value.capacityMs / cassette!.value.sidesCount) ? 'error' : 'secondary'
 })
 
 function onListKeydown(e: KeyboardEvent) {

--- a/src/components/CassetteSide.vue
+++ b/src/components/CassetteSide.vue
@@ -73,7 +73,7 @@ function onListKeydown(e: KeyboardEvent) {
 <template>
   <v-list @keydown="onListKeydown" class="grid-column">
     <v-chip size="small" variant="tonal" :color="durationChipColor">
-      {{ formatDuration(layout?.durationMs ?? 0) }} / {{ formatDuration((cassette?.capacityMs ?? 0) / 2) }}
+      {{ formatDuration(layout?.durationMs ?? 0) }} / {{ formatDuration((cassette?.capacityMs ?? 0) / cassette!.sidesCount) }}
     </v-chip>
     <v-list-subheader>
       Side {{ String.fromCharCode(65 + sideIndex) }}

--- a/src/sorting/tapeSideLayout.ts
+++ b/src/sorting/tapeSideLayout.ts
@@ -8,7 +8,7 @@ export class TapeSide {
     private capacityMs: number
 
     constructor(private cassette: Cassette, private sideIndex: number) {
-        this.capacityMs = cassette.capacityMs / 2
+        this.capacityMs = cassette.capacityMs / cassette.sidesCount
     }
 
     public anchorTrack(track: Track, index: number) {

--- a/src/stores/cassette.alert.rules.ts
+++ b/src/stores/cassette.alert.rules.ts
@@ -49,7 +49,7 @@ const shorterCassetteRule: AlertRule<ShorterCassettePayload> = {
     )
 
     const suggestedCapacity = possibleCapacitiesMs.find(
-      total => total / 2 >= longestSide
+      total => total / cassette.sidesCount >= longestSide
     )
 
     if (!suggestedCapacity || cassette.capacityMs <= suggestedCapacity)
@@ -94,7 +94,7 @@ const expandCassetteRule: AlertRule<ExpandCassettePayload> = {
     const requiredPerSide = totalDuration / 2
 
     const requiredTotal = possibleCapacitiesMs.find(
-      total => total / 2 >= requiredPerSide
+      total => total / cassette.sidesCount >= requiredPerSide
     )
 
     if (!requiredTotal || cassette.capacityMs >= requiredTotal)

--- a/src/stores/cassette.alert.rules.ts
+++ b/src/stores/cassette.alert.rules.ts
@@ -3,62 +3,67 @@ import { useCassettesStore } from "./cassette";
 import { useLayoutStore } from "./layout";
 
 const emptyCassetteRule: AlertRule = {
-  when: (cassette, sides) =>
-    sides[0]?.durationMs === 0 && sides[1]?.durationMs === 0,
+  when: (cassette, sides) => {
+    const durations = (sides || []).map(s => Number(s?.durationMs) || 0);
+    return durations.every(d => d === 0);
+  },
 
   message: () => 'Cassette is empty.',
   priority: () => 10,
 
   action: (cassette) => ({
     fn: () => {
-      const cassetteStore = useCassettesStore()
-      cassetteStore.removeCassette(cassette.id)
+      const cassetteStore = useCassettesStore();
+      cassetteStore.removeCassette(cassette.id);
     },
     message: 'Remove cassette',
   }),
-}
+};
 
-const emptySideARule: AlertRule = {
-  when: (cassette, sides) => sides[0]?.durationMs === 0,
-  message: () => 'Side A is empty.',
-  priority: () => 5,
-}
+type EmptySidePayload = { sideIndex: number }
 
-const emptySideBRule: AlertRule = {
-  when: (cassette, sides) => sides[1]?.durationMs === 0,
-  message: () => 'Side B is empty.',
+const emptySideRule: AlertRule<EmptySidePayload> = {
+  when: (_cassette, sides) => {
+    if (!Array.isArray(sides)) return false
+    const idx = sides.findIndex(s => (Number(s?.durationMs) || 0) === 0)
+    if (idx === -1) return false
+    return { sideIndex: idx }
+  },
+
+  message: (_cassette, _sides, payload) =>
+    `Side ${String.fromCharCode(65 + payload!.sideIndex)} is empty.`,
+
   priority: () => 5,
 }
 
 type ShorterCassettePayload = {
-  suggestedCapacityMs: number
-  label: string
-}
+  suggestedCapacityMs: number;
+  label: string;
+};
 
 const shorterCassetteRule: AlertRule<ShorterCassettePayload> = {
   when: (cassette, sides) => {
-    const cassetteStore = useCassettesStore()
+    const cassetteStore = useCassettesStore();
 
     const possibleCapacitiesMs = cassetteStore.possibleLengthsMin.map(
       m => m * 60_000
-    )
+    );
 
     const longestSide = Math.max(
-      sides[0].durationMs ?? 0,
-      sides[1].durationMs ?? 0
-    )
+      0,
+      ...(Array.isArray(sides) ? sides.map(s => Number(s?.durationMs) || 0) : [])
+    );
 
     const suggestedCapacity = possibleCapacitiesMs.find(
-      total => total / cassette.sidesCount >= longestSide
-    )
+      total => total / (cassette.sidesCount || 1) >= longestSide
+    );
 
-    if (!suggestedCapacity || cassette.capacityMs <= suggestedCapacity)
-      return false
+    if (!suggestedCapacity || cassette.capacityMs <= suggestedCapacity) return false;
 
     return {
       suggestedCapacityMs: suggestedCapacity,
       label: `${suggestedCapacity / 60_000} min`,
-    }
+    };
   },
 
   message: (_cassette, _sides, payload) =>
@@ -68,42 +73,43 @@ const shorterCassetteRule: AlertRule<ShorterCassettePayload> = {
 
   action: (cassette, _sides, payload) => ({
     fn: () => {
-      const layoutStore = useLayoutStore()
-      cassette.capacityMs = payload!.suggestedCapacityMs
-      layoutStore.calculateLayout()
+      const layoutStore = useLayoutStore();
+      cassette.capacityMs = payload!.suggestedCapacityMs;
+      layoutStore.calculateLayout();
     },
     message: `Set capacity to ${payload!.label}`,
   }),
-}
+};
 
 type ExpandCassettePayload = {
-  suggestedCapacityMs: number
-  label: string
-}
+  suggestedCapacityMs: number;
+  label: string;
+};
 
 const expandCassetteRule: AlertRule<ExpandCassettePayload> = {
   when: (cassette, sides) => {
-    const cassetteStore = useCassettesStore()
+    const cassetteStore = useCassettesStore();
 
     const possibleCapacitiesMs = cassetteStore.possibleLengthsMin.map(
       m => m * 60_000
-    )
+    );
 
-    const totalDuration = (sides[0]?.durationMs ?? 0) + (sides[1]?.durationMs ?? 0)
+    const totalDuration = (Array.isArray(sides)
+      ? sides.reduce((sum, s) => sum + (Number(s?.durationMs) || 0), 0)
+      : 0);
 
-    const requiredPerSide = totalDuration / 2
+    const requiredPerSide = totalDuration / (cassette.sidesCount || 1);
 
     const requiredTotal = possibleCapacitiesMs.find(
-      total => total / cassette.sidesCount >= requiredPerSide
-    )
+      total => total / (cassette.sidesCount || 1) >= requiredPerSide
+    );
 
-    if (!requiredTotal || cassette.capacityMs >= requiredTotal)
-      return false
+    if (!requiredTotal || cassette.capacityMs >= requiredTotal) return false;
 
     return {
       suggestedCapacityMs: requiredTotal,
       label: `${requiredTotal / 60_000} min`,
-    }
+    };
   },
 
   message: (_cassette, _sides, payload) =>
@@ -113,69 +119,66 @@ const expandCassetteRule: AlertRule<ExpandCassettePayload> = {
 
   action: (cassette, _sides, payload) => ({
     fn: () => {
-      const layoutStore = useLayoutStore()
-      cassette.capacityMs = payload!.suggestedCapacityMs
-      layoutStore.calculateLayout()
+      const layoutStore = useLayoutStore();
+      cassette.capacityMs = payload!.suggestedCapacityMs;
+      layoutStore.calculateLayout();
     },
     message: `Expand to ${payload!.label}`,
   }),
-}
+};
 
 type AddCassettePayload = {
-  totalDurationMs: number
-  largestCapacityMs: number
-  label: string
-}
+  totalDurationMs: number;
+  largestCapacityMs: number;
+  label: string;
+};
 
 const needsNewCassetteRule: AlertRule<AddCassettePayload> = {
-  when: (cassette, sides) => {
-    const cassetteStore = useCassettesStore()
+  when: (_cassette, sides) => {
+    const cassetteStore = useCassettesStore();
 
     const possibleCapacitiesMs = cassetteStore.possibleLengthsMin.map(
       m => m * 60_000
-    )
+    );
 
-    const largestCapacity = Math.max(...possibleCapacitiesMs)
+    const largestCapacity = Math.max(...possibleCapacitiesMs);
 
-    const totalDuration =
-      (sides[0]?.durationMs ?? 0) + (sides[1]?.durationMs ?? 0)
+    const totalDuration = (Array.isArray(sides)
+      ? sides.reduce((sum, s) => sum + (Number(s?.durationMs) || 0), 0)
+      : 0);
 
     if (totalDuration > largestCapacity) {
       return {
         totalDurationMs: totalDuration,
         largestCapacityMs: largestCapacity,
-        label: `${largestCapacity / 60_000} min`
-      }
+        label: `${largestCapacity / 60_000} min`,
+      };
     }
 
-    return false
+    return false;
   },
 
   message: (_cassette, _sides, payload) =>
-    `Total program is ${Math.ceil(
-      payload!.totalDurationMs / 60_000
-    )} min — exceeds largest cassette (${payload!.label}).`,
+    `Total program is ${Math.ceil(payload!.totalDurationMs / 60_000)} min — exceeds largest cassette (${payload!.label}).`,
 
   priority: () => 10,
 
   action: (_cassette) => ({
     fn: () => {
-      const cassetteStore = useCassettesStore()
-      const layoutStore = useLayoutStore()
+      const cassetteStore = useCassettesStore();
+      const layoutStore = useLayoutStore();
 
-      cassetteStore.addCassette()
-      layoutStore.calculateLayout()
+      cassetteStore.addCassette();
+      layoutStore.calculateLayout();
     },
     message: "Add another cassette",
   }),
-}
-
+};
 
 export const CASSETTE_ALERT_RULES: AlertRule<any>[] = [
   emptyCassetteRule,
-  emptySideARule,
-  emptySideBRule,
+  emptySideRule,
   shorterCassetteRule,
   expandCassetteRule,
   needsNewCassetteRule,
-]
+];

--- a/src/stores/cassette.ts
+++ b/src/stores/cassette.ts
@@ -16,7 +16,7 @@ export const useCassettesStore = defineStore('cassettes', {
     possibleLengthsMin: [60, 90, 120],
     metadata: {} as CassetteMetadata,
     cassettes: [
-      { id: 'default', name: 'My First Cassette', capacityMs: 90 * 60000, sidesCount: 3 },
+      { id: 'default', name: 'My First Cassette', capacityMs: 90 * 60000, sidesCount: 2 },
     ] as Cassette[],
     alerts: {} as Record<string, CassetteAlert>,
   }),
@@ -56,6 +56,16 @@ export const useCassettesStore = defineStore('cassettes', {
       const cassette = this.getCassetteById(cassetteId)
       if (cassette) {
         cassette.capacityMs = newCapacityMs
+      }
+    },
+
+    updateSidesCount(cassetteId: string, newSidesCount: number) {
+      if (newSidesCount < 1) {
+        throw new Error("New sides count cannot be less than 1.")
+      }
+      const cassette = this.getCassetteById(cassetteId)
+      if (cassette) {
+        cassette.sidesCount = newSidesCount
       }
     },
 

--- a/src/stores/cassette.ts
+++ b/src/stores/cassette.ts
@@ -16,7 +16,7 @@ export const useCassettesStore = defineStore('cassettes', {
     possibleLengthsMin: [60, 90, 120],
     metadata: {} as CassetteMetadata,
     cassettes: [
-      { id: 'default', name: 'My First Cassette', capacityMs: 90 * 60000 },
+      { id: 'default', name: 'My First Cassette', capacityMs: 90 * 60000, sidesCount: 3 },
     ] as Cassette[],
     alerts: {} as Record<string, CassetteAlert>,
   }),
@@ -36,6 +36,7 @@ export const useCassettesStore = defineStore('cassettes', {
         id: uuidv4(),
         name: `${this.metadata.item_name} ${this.cassettes.length + 1}`,
         capacityMs: 90 * 60000,
+        sidesCount: 2
       })
     },
 

--- a/src/stores/cassette.ts
+++ b/src/stores/cassette.ts
@@ -13,7 +13,7 @@ import { useLayoutStore } from './layout'
 
 export const useCassettesStore = defineStore('cassettes', {
   state: () => ({
-    possibleLengthsMin: [60, 90, 120],
+    possibleLengthsMin: [30, 45, 60, 90, 120],
     metadata: {} as CassetteMetadata,
     cassettes: [
       { id: 'default', name: 'My First Cassette', capacityMs: 90 * 60000, sidesCount: 2 },

--- a/src/stores/layout.ts
+++ b/src/stores/layout.ts
@@ -71,7 +71,7 @@ export const useLayoutStore = defineStore('layout', {
             const sides: TapeSide[] = []
 
             for (const cassette of cassetteStore.cassettes) {
-                for (let sideIndex = 0; sideIndex < 2; sideIndex++) {
+                for (let sideIndex = 0; sideIndex < cassette.sidesCount; sideIndex++) {
                     const side = new TapeSide(cassette, sideIndex)
                     sides.push(side)
                 }

--- a/src/types/tapeify/models.ts
+++ b/src/types/tapeify/models.ts
@@ -98,24 +98,24 @@ export interface CassetteAlert {
 export type AlertRule<TPayload = any> = {
   when: (
     cassette: Cassette,
-    sides: Record<number, TapeSideLayout>
+    sides: Array<TapeSideLayout>
   ) => boolean | TPayload
 
   message: (
     cassette: Cassette,
-    sides: Record<number, TapeSideLayout>,
+    sides: Array<TapeSideLayout>,
     payload?: TPayload
   ) => string
 
   priority: (
     cassette: Cassette,
-    sides: Record<number, TapeSideLayout>,
+    sides: Array<TapeSideLayout>,
     payload?: TPayload
   ) => number
 
   action?: (
     cassette: Cassette,
-    sides: Record<number, TapeSideLayout>,
+    sides: Array<TapeSideLayout>,
     payload?: TPayload
   ) => CassetteAlert['action']
 }

--- a/src/types/tapeify/models.ts
+++ b/src/types/tapeify/models.ts
@@ -39,6 +39,7 @@ export interface Cassette {
   name: string
   id: string
   capacityMs: number
+  sidesCount: number
 }
 
 export interface Anchor {


### PR DESCRIPTION
Added a sides count to the cassettes object and removed all hard coded references to cassettes only having 2 sides. Added menu to cassette UI component that has options to add/remove cassettes and sides. Cassettes can now have any number of sides.
## Single Cassette
<img width="800" height="417" alt="single-cassette" src="https://github.com/user-attachments/assets/e12b5a06-2c8e-437d-ac31-333adc20848b" />

## Multi Cassette
<img width="800" height="417" alt="multi-cassette" src="https://github.com/user-attachments/assets/490c6da5-86b8-4f74-a324-a6e8560c1484" />
